### PR TITLE
Fix comment typo

### DIFF
--- a/main.c
+++ b/main.c
@@ -89,7 +89,7 @@ void main(void)
 	// enable frame timer
 	TIM4_CR1 |= 0b00000001;
 
-	// globle interrupt enable
+        // global interrupt enable
 	__asm__("rim");
 
 //	uart_send("6", 2);


### PR DESCRIPTION
## Summary
- clean up comment in `main.c`

## Testing
- `make clean && make` *(fails: sdcc-sdcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684309f16ff88326ac1cc9f6c4135052