### PR TITLE
Fix shebang for conf.sh

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 MODBUS_ADDR=1
 fMASTER=2000000


### PR DESCRIPTION
## Summary
- fix the shebang so `conf.sh` runs with `/bin/sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430ab0530483268c437b37fd016248