### PR TITLE
Fix configuration instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ This project implements a Modbus RTU slave device specifically designed for the 
 
 Before compiling and flashing the software, configure the UART and Modbus settings using the provided script. This script tailors the necessary UART and timer settings based on specified parameters (Modbus address, baud rate, and master clock frequency) and prepares them for EEPROM storage.
 
-1. **Run the Configuration Script:**
+1. **Run the Configuration Script from the project root:**
    ```
-   cd config
    chmod +x conf.sh
    ./conf.sh
    ```


### PR DESCRIPTION
## Summary
- correct README configuration instructions

## Testing
- `make` *(fails: sdcc-sdcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430abeeb108326aece8a28dc1d2f89