### PR TITLE
Add CRC16 unit test and make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,15 @@ all:
 	$(CC) -c main.c $(CFLAGS) $(LIBS)
 	$(CC) *.rel $(CFLAGS) $(LIBS)
 
+test: crc16_test
+	./crc16_test
+
+crc16_test: modbus.c crc16_test.c
+	gcc -std=c99 -Wall -Wextra -I. crc16_test.c modbus.c -o crc16_test
+
 install:
-#	stm8flash -c stlinkv2 -p stm8s105k4 -w main.ihx
-	stm8flash -c stlinkv2 -p stm8s003f3 -w main.ihx
+		#	stm8flash -c stlinkv2 -p stm8s105k4 -w main.ihx
+		stm8flash -c stlinkv2 -p stm8s003f3 -w main.ihx
 
 clean:
-	rm -f *.asm *.ihx *.lst *.rel *.sym *.lk *.map *.rst *.eeprom
+	rm -f *.asm *.ihx *.lst *.rel *.sym *.lk *.map *.rst *.eeprom crc16_test

--- a/crc16_test.c
+++ b/crc16_test.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+
+uint16_t crc16(const uint8_t *nData, uint16_t wLength);
+
+int main(void) {
+    const char *test_str = "123456789";
+    uint16_t crc = crc16((const uint8_t *)test_str, strlen(test_str));
+    assert(crc == 0x4B37);
+    return 0;
+}

--- a/modbus.h
+++ b/modbus.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef __SDCC
 #include <asm/stm8/features.h>
+#endif
 
 #define READ_COIL_STATUS 01
 #define READ_INPUT_STATUS 02


### PR DESCRIPTION
## Summary
- add a minimal CRC16 test program
- conditionally include `features.h` only when building with SDCC
- extend Makefile with `test` target using gcc and clean rule

## Testing
- `make clean`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68430ac203888326b86b54c148a62c82